### PR TITLE
New methosds added, compiler warnings removed

### DIFF
--- a/Java/Concentus/src/main/java/org/concentus/OpusDecoder.java
+++ b/Java/Concentus/src/main/java/org/concentus/OpusDecoder.java
@@ -729,9 +729,9 @@ public class OpusDecoder {
     public int decode(byte[] in_data, int in_data_offset,
             int len, byte[] out_pcm, int out_pcm_offset, int frame_size, boolean decode_fec) throws OpusException {
     	short[] spcm = new short[out_pcm.length / 2];
-    	int decSamples = decode(in_data, in_data_offset, len, spcm, out_pcm_offset, frame_size, decode_fec);
+    	int decSamples = decode(in_data, in_data_offset, len, spcm, 0, frame_size, decode_fec);
     	//Convert short array to byte array
-    	for (int c = 0; c < spcm.length; c++) {
+    	for (int c = out_pcm_offset; c < spcm.length; c++) {
     		out_pcm[c * 2] = (byte) (spcm[c] & 0xff);
     		out_pcm[c * 2 + 1] = (byte) ((spcm[c] >> 8) & 0xff);
     	}

--- a/Java/Concentus/src/main/java/org/concentus/OpusDecoder.java
+++ b/Java/Concentus/src/main/java/org/concentus/OpusDecoder.java
@@ -157,7 +157,6 @@ public class OpusDecoder {
      */
     public OpusDecoder(int Fs, int channels) throws OpusException {
         int ret;
-        OpusDecoder st; // porting note: pointer
         if ((Fs != 48000 && Fs != 24000 && Fs != 16000 && Fs != 12000 && Fs != 8000)) {
             throw new IllegalArgumentException("Sample rate is invalid (must be 8/12/16/24/48 Khz)");
         }
@@ -515,7 +514,7 @@ public class OpusDecoder {
 
         if (this.decode_gain != 0) {
             int gain;
-            gain = Inlines.celt_exp2(Inlines.MULT16_16_P15(((short) (0.5 + (6.48814081e-4f) * (((int) 1) << (25))))/*Inlines.QCONST16(6.48814081e-4f, 25)*/, this.decode_gain));
+            gain = Inlines.celt_exp2(Inlines.MULT16_16_P15(((short) (0.5 + (6.48814081e-4f) * ((1) << (25))))/*Inlines.QCONST16(6.48814081e-4f, 25)*/, this.decode_gain));
             for (i = pcm_ptr; i < pcm_ptr + (frame_size * this.channels); i++) {
                 int x;
                 x = Inlines.MULT16_32_P16(pcm[i], gain);
@@ -540,7 +539,6 @@ public class OpusDecoder {
             int self_delimited, BoxedValueInt packet_offset, int soft_clip) {
         int i, nb_samples;
         int count, offset;
-        byte toc;
         int packet_frame_size, packet_stream_channels;
         packet_offset.Val = 0;
         OpusBandwidth packet_bandwidth;
@@ -581,7 +579,6 @@ public class OpusDecoder {
         BoxedValueInt boxed_offset = new BoxedValueInt(0);
         count = OpusPacketInfo.opus_packet_parse_impl(data, data_ptr, len, self_delimited, boxed_toc, null, 0,
                 size, 0, boxed_offset, packet_offset);
-        toc = boxed_toc.Val;
         offset = boxed_offset.Val;
 
         if (count < 0) {
@@ -668,7 +665,7 @@ public class OpusDecoder {
      * @param in_data The input payload. This may be NULL if that previous packet was lost in transit (when PLC is enabled)
      * @param in_data_offset The offset to use when reading the input payload. Usually 0
      * @param len The number of bytes in the payload (the packet size)
-     * @param out_pcm A buffer to put the output PCM. The output size is (# of samples) * (# of channels).
+     * @param out_pcm A buffer to put the output PCM, in a short array. The output size is (# of samples) * (# of channels).
      *      You can use the OpusPacketInfo helpers to get a hint of the frame size before you decode the packet if you need exact sizing.
      * @param out_pcm_offset The offset to use when writing to the output buffer
      * @param frame_size The number of samples (per channel) of available space in the output PCM buf.
@@ -687,7 +684,7 @@ public class OpusDecoder {
     public int decode(byte[] in_data, int in_data_offset,
             int len, short[] out_pcm, int out_pcm_offset, int frame_size, boolean decode_fec) throws OpusException {
         if (frame_size <= 0) {
-            throw new IllegalArgumentException("Frame size must be <= 0");
+            throw new IllegalArgumentException("Frame size must be > 0");
         }
 
         try {
@@ -706,6 +703,39 @@ public class OpusDecoder {
         } catch (ArithmeticException e) {
             throw new OpusException("Internal error during decoding: " + e.getMessage());
         }
+    }
+
+    /**
+     * Decodes an Opus packet.
+     * @param in_data The input payload. This may be NULL if that previous packet was lost in transit (when PLC is enabled)
+     * @param in_data_offset The offset to use when reading the input payload. Usually 0
+     * @param len The number of bytes in the payload (the packet size)
+     * @param out_pcm A buffer to put the output PCM, in a byte array. The output size is (# of samples) * (# of channels) * 2.
+     *      You can use the OpusPacketInfo helpers to get a hint of the frame size before you decode the packet if you need exact sizing.
+     * @param out_pcm_offset The offset to use when writing to the output buffer
+     * @param frame_size The number of samples (per channel) of available space in the output PCM buf.
+     * If this is less than the maximum packet duration (120ms; 5760 for 48khz), this function will
+     * not be capable of decoding some packets. In the case of PLC (data == NULL) or FEC (decode_fec == true),
+     * then frame_size needs to be exactly the duration of the audio that is missing, otherwise the decoder will
+     * not be in an optimal state to decode the next incoming packet. For the PLC and FEC cases, frame_size *must*
+     * be a multiple of 2.5 ms.
+     * @param decode_fec Indicates that we want to recreate the PREVIOUS (lost) packet using FEC data from THIS packet. Using this packet
+     * recovery scheme, you will actually decode this packet twice, first with decode_fec TRUE and then again with FALSE. If FEC data is not
+     * available in this packet, the decoder will simply generate a best-effort recreation of the lost packet. In that case,
+     * the length of frame_size must be EXACTLY the length of the audio that was lost, or else the decoder will be in an inconsistent state.
+     * @return The number of decoded samples (per channel)
+     * @throws OpusException 
+     */
+    public int decode(byte[] in_data, int in_data_offset,
+            int len, byte[] out_pcm, int out_pcm_offset, int frame_size, boolean decode_fec) throws OpusException {
+    	short[] spcm = new short[out_pcm.length / 2];
+    	int decSamples = decode(in_data, in_data_offset, len, spcm, out_pcm_offset, frame_size, decode_fec);
+    	//Convert short array to byte array
+    	for (int c = 0; c < spcm.length; c++) {
+    		out_pcm[c * 2] = (byte) (spcm[c] & 0xff);
+    		out_pcm[c * 2 + 1] = (byte) ((spcm[c] >> 8) & 0xff);
+    	}
+    	return decSamples;
     }
 
     public OpusBandwidth getBandwidth() {

--- a/Java/Concentus/src/main/java/org/concentus/OpusEncoder.java
+++ b/Java/Concentus/src/main/java/org/concentus/OpusEncoder.java
@@ -121,7 +121,7 @@ public class OpusEncoder {
         hybrid_stereo_width_Q14 = 0;
         variable_HP_smth2_Q15 = 0;
         prev_HB_gain = 0;
-        Arrays.MemSet(hp_mem, (int) 0, 4);
+        Arrays.MemSet(hp_mem, 0, 4);
         mode = OpusMode.MODE_UNKNOWN;
         prev_mode = OpusMode.MODE_UNKNOWN;
         prev_channels = 0;
@@ -187,7 +187,6 @@ public class OpusEncoder {
      */
     public OpusEncoder(int Fs, int channels, OpusApplication application) throws OpusException {
         int ret;
-        OpusEncoder st;
         if ((Fs != 48000 && Fs != 24000 && Fs != 16000 && Fs != 12000 && Fs != 8000)) {
             throw new IllegalArgumentException("Sample rate is invalid (must be 8/12/16/24/48 Khz)");
         }
@@ -437,7 +436,7 @@ public class OpusEncoder {
             int frame_rate3 = 3 * this.Fs / frame_size;
             /* We need to make sure that "int" values always fit in 16 bits. */
             cbrBytes = Inlines.IMIN((3 * this.bitrate_bps / 8 + frame_rate3 / 2) / frame_rate3, max_data_bytes);
-            this.bitrate_bps = cbrBytes * (int) frame_rate3 * 8 / 3;
+            this.bitrate_bps = cbrBytes * frame_rate3 * 8 / 3;
             max_data_bytes = cbrBytes;
         }
         if (max_data_bytes < 3 || this.bitrate_bps < 3 * frame_rate * 8
@@ -516,10 +515,10 @@ public class OpusEncoder {
             int threshold;
 
             /* Interpolate based on stereo width */
-            mode_voice = (int) (Inlines.MULT16_32_Q15(CeltConstants.Q15ONE - stereo_width, OpusTables.mode_thresholds[0][0])
-                    + Inlines.MULT16_32_Q15(stereo_width, OpusTables.mode_thresholds[1][0]));
-            mode_music = (int) (Inlines.MULT16_32_Q15(CeltConstants.Q15ONE - stereo_width, OpusTables.mode_thresholds[1][1])
-                    + Inlines.MULT16_32_Q15(stereo_width, OpusTables.mode_thresholds[1][1]));
+            mode_voice = Inlines.MULT16_32_Q15(CeltConstants.Q15ONE - stereo_width, OpusTables.mode_thresholds[0][0])
+                    + Inlines.MULT16_32_Q15(stereo_width, OpusTables.mode_thresholds[1][0]);
+            mode_music = Inlines.MULT16_32_Q15(CeltConstants.Q15ONE - stereo_width, OpusTables.mode_thresholds[1][1])
+                    + Inlines.MULT16_32_Q15(stereo_width, OpusTables.mode_thresholds[1][1]);
             /* Interpolate based on speech/music probability */
             threshold = mode_music + ((voice_est * voice_est * (mode_voice - mode_music)) >> 14);
             /* Bias towards SILK for VoIP because of some useful features */
@@ -595,7 +594,7 @@ public class OpusEncoder {
 
         if (redundancy != 0) {
             /* Fair share of the max size allowed */
-            redundancy_bytes = Inlines.IMIN(257, max_data_bytes * (int) (this.Fs / 200) / (frame_size + this.Fs / 200));
+            redundancy_bytes = Inlines.IMIN(257, max_data_bytes * (this.Fs / 200) / (frame_size + this.Fs / 200));
             /* For VBR, target the actual bitrate (subject to the limit above) */
             if (this.use_vbr != 0) {
                 redundancy_bytes = Inlines.IMIN(redundancy_bytes, this.bitrate_bps / 1600);
@@ -863,7 +862,7 @@ public class OpusEncoder {
                     /* Increasingly attenuate high band when it gets allocated fewer bits */
                     celt_rate = total_bitRate - this.silk_mode.bitRate;
                     HB_gain_ref = (curr_bandwidth == OpusBandwidth.OPUS_BANDWIDTH_SUPERWIDEBAND) ? 3000 : 3600;
-                    HB_gain = Inlines.SHL32((int) celt_rate, 9) / Inlines.SHR32((int) celt_rate + this.stream_channels * HB_gain_ref, 6);
+                    HB_gain = Inlines.SHL32(celt_rate, 9) / Inlines.SHR32(celt_rate + this.stream_channels * HB_gain_ref, 6);
                     HB_gain = HB_gain < CeltConstants.Q15ONE * 6 / 7 ? HB_gain + CeltConstants.Q15ONE / 7 : CeltConstants.Q15ONE;
                 }
             } else {
@@ -890,7 +889,7 @@ public class OpusEncoder {
                     for (i = 0; i < end; i++) {
                         int mask;
                         mask = Inlines.MAX16(Inlines.MIN16(this.energy_masking[21 * c + i],
-                                ((short) (0.5 + (.5f) * (((int) 1) << (10))))/*Inlines.QCONST16(.5f, 10)*/), -((short) (0.5 + (2.0f) * (((int) 1) << (10))))/*Inlines.QCONST16(2.0f, 10)*/);
+                                ((short) (0.5 + (.5f) * ((1) << (10))))/*Inlines.QCONST16(.5f, 10)*/), -((short) (0.5 + (2.0f) * ((1) << (10))))/*Inlines.QCONST16(2.0f, 10)*/);
                         if (mask > 0) {
                             mask = Inlines.HALF16(mask);
                         }
@@ -899,8 +898,8 @@ public class OpusEncoder {
                 }
                 /* Conservative rate reduction, we cut the masking in half */
                 masking_depth = mask_sum / end * this.channels;
-                masking_depth += ((short) (0.5 + (.2f) * (((int) 1) << (10))))/*Inlines.QCONST16(.2f, 10)*/;
-                rate_offset = (int) Inlines.PSHR32(Inlines.MULT16_16(srate, masking_depth), 10);
+                masking_depth += ((short) (0.5 + (.2f) * ((1) << (10))))/*Inlines.QCONST16(.2f, 10)*/;
+                rate_offset = Inlines.PSHR32(Inlines.MULT16_16(srate, masking_depth), 10);
                 rate_offset = Inlines.MAX32(rate_offset, -2 * this.silk_mode.bitRate / 3);
                 /* Split the rate change between the SILK and CELT part for hybrid. */
                 if (this.bandwidth == OpusBandwidth.OPUS_BANDWIDTH_SUPERWIDEBAND || this.bandwidth == OpusBandwidth.OPUS_BANDWIDTH_FULLBAND) {
@@ -955,7 +954,7 @@ public class OpusEncoder {
             this.silk_mode.maxBits = nBytes * 8;
             /* Only allow up to 90% of the bits for hybrid mode*/
             if (this.mode == OpusMode.MODE_HYBRID) {
-                this.silk_mode.maxBits = (int) this.silk_mode.maxBits * 9 / 10;
+                this.silk_mode.maxBits = this.silk_mode.maxBits * 9 / 10;
             }
             if (this.silk_mode.useCBR != 0) {
                 this.silk_mode.maxBits = (this.silk_mode.bitRate * frame_size / (this.Fs * 8)) * 8;
@@ -1114,7 +1113,7 @@ public class OpusEncoder {
             if (this.hybrid_stereo_width_Q14 < (1 << 14) || this.silk_mode.stereoWidth_Q14 < (1 << 14)) {
                 int g1, g2;
                 g1 = this.hybrid_stereo_width_Q14;
-                g2 = (int) (this.silk_mode.stereoWidth_Q14);
+                g2 = (this.silk_mode.stereoWidth_Q14);
                 g1 = g1 == 16384 ? CeltConstants.Q15ONE : Inlines.SHL16(g1, 1);
                 g2 = g2 == 16384 ? CeltConstants.Q15ONE : Inlines.SHL16(g2, 1);
                 CodecHelpers.stereo_fade(pcm_buf, g1, g2, celt_mode.overlap,
@@ -1274,7 +1273,7 @@ public class OpusEncoder {
 
     /**
      * Encodes an Opus frame, putting the output into a specified data buffer
-     * @param in_pcm 16-bit input signal (Interleaved if stereo). Length should be at least frame_size * channels
+     * @param in_pcm 16-bit input signal (Interleaved if stereo), in a short array. Length should be at least frame_size * channels
      * @param pcm_offset Offset to use when reading the in_pcm buffer
      * @param frame_size The number of samples _per channel_ in the inpus signal. The frame size must be a valid Opus framesize for the given sample rate.
      * For example, at 48Khz the permitted values are 120, 240, 480, 960, 1920, and 2880. Passing in a duration of less than 10ms
@@ -1327,6 +1326,32 @@ public class OpusEncoder {
         }
     }
 
+    /**
+     * Encodes an Opus frame, putting the output into a specified data buffer
+     * @param in_pcm 16-bit input signal (Interleaved if stereo), in a byte array. Length should be at least frame_size * channels * 2
+     * @param pcm_offset Offset to use when reading the in_pcm buffer
+     * @param frame_size The number of samples _per channel_ in the inpus signal. The frame size must be a valid Opus framesize for the given sample rate.
+     * For example, at 48Khz the permitted values are 120, 240, 480, 960, 1920, and 2880. Passing in a duration of less than 10ms
+     * (480 samples at 48Khz) will prevent the encoder from using FEC, DTX, or hybrid modes.
+     * @param out_data Destination buffer for the output payload. This must contain at least max_data_bytes
+     * @param out_data_offset The offset to use when writing to the output data buffer
+     * @param max_data_bytes The maximum amount of space allocated for the output payload. This may be used to impose
+     * an upper limit on the instant bitrate, but should not be used as the only bitrate control (use setBitrate for that)
+     * @return The length of the encoded packet, in bytes
+     * @throws OpusException 
+     */
+    public int encode(byte[] in_pcm, int pcm_offset, int frame_size,
+            byte[] out_data, int out_data_offset, int max_data_bytes) throws OpusException {
+    	//Convert byte array to short array
+    	short[] spcm = new short[in_pcm.length / 2];
+		for (int c = 0; c < spcm.length; c++) {
+			short x = (short) ((in_pcm[(c * 2)]) & 0xff);
+			short y = (short) ((in_pcm[(c * 2) + 1]) << 8);
+			spcm[c] = (short) (x | y);
+		}
+		return encode(spcm, pcm_offset, frame_size, out_data, out_data_offset, max_data_bytes);
+    }
+
     /// <summary>
     /// Gets or sets the application (or signal type) of the input signal. This hints
     /// to the encoder what type of details we want to preserve in the encoding.
@@ -1357,8 +1382,8 @@ public class OpusEncoder {
                 throw new IllegalArgumentException("Bitrate must be positive");
             } else if (value <= 500) {
                 value = 500;
-            } else if (value > (int) 300000 * channels) {
-                value = (int) 300000 * channels;
+            } else if (value > 300000 * channels) {
+                value = 300000 * channels;
             }
         }
 

--- a/Java/Concentus/src/main/java/org/concentus/OpusEncoder.java
+++ b/Java/Concentus/src/main/java/org/concentus/OpusEncoder.java
@@ -1328,7 +1328,7 @@ public class OpusEncoder {
 
     /**
      * Encodes an Opus frame, putting the output into a specified data buffer
-     * @param in_pcm 16-bit input signal (Interleaved if stereo), in a byte array. Length should be at least frame_size * channels * 2
+     * @param in_pcm 16-bit input signal (Interleaved if stereo), in a little endian byte array. Length should be at least frame_size * channels * 2
      * @param pcm_offset Offset to use when reading the in_pcm buffer
      * @param frame_size The number of samples _per channel_ in the inpus signal. The frame size must be a valid Opus framesize for the given sample rate.
      * For example, at 48Khz the permitted values are 120, 240, 480, 960, 1920, and 2880. Passing in a duration of less than 10ms
@@ -1343,13 +1343,13 @@ public class OpusEncoder {
     public int encode(byte[] in_pcm, int pcm_offset, int frame_size,
             byte[] out_data, int out_data_offset, int max_data_bytes) throws OpusException {
     	//Convert byte array to short array
-    	short[] spcm = new short[in_pcm.length / 2];
-		for (int c = 0; c < spcm.length; c++) {
+    	short[] spcm = new short[(in_pcm.length - pcm_offset) / 2];
+		for (int c = pcm_offset; c < spcm.length; c++) {
 			short x = (short) ((in_pcm[(c * 2)]) & 0xff);
 			short y = (short) ((in_pcm[(c * 2) + 1]) << 8);
 			spcm[c] = (short) (x | y);
 		}
-		return encode(spcm, pcm_offset, frame_size, out_data, out_data_offset, max_data_bytes);
+		return encode(spcm, 0, frame_size, out_data, out_data_offset, max_data_bytes);
     }
 
     /// <summary>


### PR DESCRIPTION
- Added methods in OpusDecoder and OpusEncoder that use byte array
instead short array (Java Sound API uses byte arrays for PCM data).
These methods call corresponding methods that use short array and
convert array types internally.

- Some compiler warnings are treated: unused variables, unnecessary
casts.

- Made the changes requested by lostromb.