### PR TITLE
Add LICENSE file to NuGet pkg

### DIFF
--- a/CSharp/Concentus.props
+++ b/CSharp/Concentus.props
@@ -15,7 +15,7 @@
     <Authors>Logan Stromberg</Authors>
     <PackageProjectUrl>https://github.com/lostromb/concentus</PackageProjectUrl>
     <PackageIconUrl>http://durandal.dnsalias.net/imgur/concentus.png</PackageIconUrl>
-    <PackageLicenseFile>LICENSE</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <Copyright>Copyright © Xiph.Org Foundation, Skype Limited, CSIRO, Microsoft Corp.</Copyright>
     <PackageReleaseNotes>1.1.7 Including .Net 3.5 was a mistake as it becomes the default for everyone</PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>

--- a/CSharp/Concentus.props
+++ b/CSharp/Concentus.props
@@ -15,7 +15,7 @@
     <Authors>Logan Stromberg</Authors>
     <PackageProjectUrl>https://github.com/lostromb/concentus</PackageProjectUrl>
     <PackageIconUrl>http://durandal.dnsalias.net/imgur/concentus.png</PackageIconUrl>
-    <PackageLicenseUrl>https://opus-codec.org/license/</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE</PackageLicenseUrl>
     <Copyright>Copyright © Xiph.Org Foundation, Skype Limited, CSIRO, Microsoft Corp.</Copyright>
     <PackageReleaseNotes>1.1.7 Including .Net 3.5 was a mistake as it becomes the default for everyone</PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
@@ -32,6 +32,7 @@
   <ItemGroup>
     <Compile Include="$(SourceDir)\**\*.cs" Exclude="$(SourceDir)\bin\**;$(SourceDir)\obj\**" />
     <Content Include="$(SourceDir)\Readme.txt" PackagePath="" />
+    <None Include="$(MSBuildThisFileDirectory)\..\LICENSE" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(UnsafeBuild)' == 'true'">


### PR DESCRIPTION
The [PackageLicenseUrl](https://learn.microsoft.com/en-us/nuget/reference/msbuild-targets#pack-target-inputs) property has been deprecated.
Instead we are supposed to use `PackageLicenseExpression` or `PackageLicenseFile` now.

This PR replaces `PackageLicenseUrl` with `PackageLicenseFile` and includes the license file in the NuGet package, as required by this license.