### PR TITLE
Fix compilation bug

### DIFF
--- a/Go/README.md
+++ b/Go/README.md
@@ -1,3 +1,7 @@
 ## Performance Note
 
 This Go version is a direct translation from the Java code. For the same input sample, it produces identical output while achieving approximately **40% faster execution time**. Go is also one of the best languages for cross-platform development.
+
+
+## How to use
+go get "github.com/lostromb/concentus/go

--- a/Go/READMEzh.md
+++ b/Go/READMEzh.md
@@ -1,3 +1,8 @@
 ## 性能说明
 
 此 Golang 版本通过 Java 版本纯翻译而成。对于同一个样本，输出结果完全一致，但执行时间快了约 **40%**。同时，Golang 也是跨平台开发的最佳语言选择之一。
+
+
+
+## 使用方法
+go get "github.com/lostromb/concentus/go

--- a/Go/celt/CWRS.go
+++ b/Go/celt/CWRS.go
@@ -1,6 +1,6 @@
 package celt
 
-import "github.com/dosgo/concentus/go/comm"
+import "github.com/lostromb/concentus/go/comm"
 
 var CELT_PVQ_U_ROW = []int{
 	0, 176, 351, 525, 698, 870, 1041, 1131, 1178, 1207, 1226, 1240, 1248, 1254, 1257,

--- a/Go/celt/Laplace.go
+++ b/Go/celt/Laplace.go
@@ -1,6 +1,6 @@
 package celt
 
-import "github.com/dosgo/concentus/go/comm"
+import "github.com/lostromb/concentus/go/comm"
 
 /* Copyright (c) 2007-2008 CSIRO
    Copyright (c) 2007-2011 Xiph.Org Foundation

--- a/Go/celt/Pitch.go
+++ b/Go/celt/Pitch.go
@@ -3,7 +3,7 @@ package celt
 import (
 	"math"
 
-	"github.com/dosgo/concentus/go/comm"
+	"github.com/lostromb/concentus/go/comm"
 )
 
 func find_best_pitch(xcorr []int, y []int, len int, max_pitch int, best_pitch []int, yshift int, maxcorr int) {

--- a/Go/celt/QuantizeBands.go
+++ b/Go/celt/QuantizeBands.go
@@ -1,6 +1,6 @@
 package celt
 
-import "github.com/dosgo/concentus/go/comm"
+import "github.com/lostromb/concentus/go/comm"
 
 var pred_coef = []int{29440, 26112, 21248, 16384}
 var beta_coef = []int{30147, 22282, 12124, 6554}

--- a/Go/celt/Rate.go
+++ b/Go/celt/Rate.go
@@ -1,7 +1,7 @@
 package celt
 
 import (
-	"github.com/dosgo/concentus/go/comm"
+	"github.com/lostromb/concentus/go/comm"
 )
 
 const ALLOC_STEPS = 6

--- a/Go/celt/VQ.go
+++ b/Go/celt/VQ.go
@@ -3,7 +3,7 @@ package celt
 import (
 	"math"
 
-	"github.com/dosgo/concentus/go/comm"
+	"github.com/lostromb/concentus/go/comm"
 )
 
 var SPREAD_FACTOR = [3]int{15, 10, 5}

--- a/Go/celt/bands.go
+++ b/Go/celt/bands.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/dosgo/concentus/go/comm"
-	"github.com/dosgo/concentus/go/comm/arrayUtil"
+	"github.com/lostromb/concentus/go/comm"
+	"github.com/lostromb/concentus/go/comm/arrayUtil"
 )
 
 type band_ctx struct {

--- a/Go/celt/celt_LPC.go
+++ b/Go/celt/celt_LPC.go
@@ -1,6 +1,6 @@
 package celt
 
-import "github.com/dosgo/concentus/go/comm"
+import "github.com/lostromb/concentus/go/comm"
 
 func celt_lpc(_lpc []int, ac []int, p int) {
 	var i, j int

--- a/Go/celt/celt_common.go
+++ b/Go/celt/celt_common.go
@@ -3,8 +3,8 @@ package celt
 import (
 	"math"
 
-	"github.com/dosgo/concentus/go/comm"
-	"github.com/dosgo/concentus/go/comm/arrayUtil"
+	"github.com/lostromb/concentus/go/comm"
+	"github.com/lostromb/concentus/go/comm/arrayUtil"
 )
 
 var inv_table = []int16{

--- a/Go/celt/celt_decoder.go
+++ b/Go/celt/celt_decoder.go
@@ -3,8 +3,8 @@ package celt
 import (
 	"math"
 
-	"github.com/dosgo/concentus/go/comm"
-	"github.com/dosgo/concentus/go/comm/arrayUtil"
+	"github.com/lostromb/concentus/go/comm"
+	"github.com/lostromb/concentus/go/comm/arrayUtil"
 )
 
 type CeltDecoder struct {

--- a/Go/celt/celt_encoder.go
+++ b/Go/celt/celt_encoder.go
@@ -3,9 +3,9 @@ package celt
 import (
 	"math"
 
-	"github.com/dosgo/concentus/go/comm"
-	"github.com/dosgo/concentus/go/comm/arrayUtil"
-	"github.com/dosgo/concentus/go/comm/opusConstants"
+	"github.com/lostromb/concentus/go/comm"
+	"github.com/lostromb/concentus/go/comm/arrayUtil"
+	"github.com/lostromb/concentus/go/comm/opusConstants"
 )
 
 type CeltEncoder struct {

--- a/Go/celt/import.go
+++ b/Go/celt/import.go
@@ -1,6 +1,6 @@
 package celt
 
-import "github.com/dosgo/concentus/go/comm"
+import "github.com/lostromb/concentus/go/comm"
 
 var inlines = comm.Inlines{}
 var kernels = comm.Kernels{}

--- a/Go/comm/EntropyCoder.go
+++ b/Go/comm/EntropyCoder.go
@@ -3,7 +3,7 @@ package comm
 import (
 	"fmt"
 
-	"github.com/dosgo/concentus/go/comm/arrayUtil"
+	"github.com/lostromb/concentus/go/comm/arrayUtil"
 )
 
 const (

--- a/Go/go.mod
+++ b/Go/go.mod
@@ -1,3 +1,3 @@
-module github.com/dosgo/concentus/go
+module github.com/lostromb/concentus/go
 
-go 1.25rc1
+go 1.20

--- a/Go/opus/CodecHelpers.go
+++ b/Go/opus/CodecHelpers.go
@@ -3,8 +3,8 @@ package opus
 import (
 	"math"
 
-	"github.com/dosgo/concentus/go/celt"
-	"github.com/dosgo/concentus/go/silk"
+	"github.com/lostromb/concentus/go/celt"
+	"github.com/lostromb/concentus/go/silk"
 )
 
 func gen_toc(mode int, framerate int, bandwidth int, channels int) byte {

--- a/Go/opus/DecodeAPI.go
+++ b/Go/opus/DecodeAPI.go
@@ -1,8 +1,8 @@
 package opus
 
 import (
-	"github.com/dosgo/concentus/go/comm"
-	"github.com/dosgo/concentus/go/silk"
+	"github.com/lostromb/concentus/go/comm"
+	"github.com/lostromb/concentus/go/silk"
 )
 
 func silk_InitDecoder(decState *silk.SilkDecoder) int {

--- a/Go/opus/EncodeAPI.go
+++ b/Go/opus/EncodeAPI.go
@@ -3,8 +3,8 @@ package opus
 import (
 	"math"
 
-	"github.com/dosgo/concentus/go/comm"
-	"github.com/dosgo/concentus/go/silk"
+	"github.com/lostromb/concentus/go/comm"
+	"github.com/lostromb/concentus/go/silk"
 )
 
 func silk_InitEncoder(encState *silk.SilkEncoder, encStatus *silk.EncControlState) int {

--- a/Go/opus/HPVariableCutoff.go
+++ b/Go/opus/HPVariableCutoff.go
@@ -1,6 +1,6 @@
 package opus
 
-import "github.com/dosgo/concentus/go/silk"
+import "github.com/lostromb/concentus/go/silk"
 
 func silk_HP_variable_cutoff(state_Fxx []*silk.SilkChannelEncoder) {
 	var quality_Q15 int

--- a/Go/opus/OpusDecoder.go
+++ b/Go/opus/OpusDecoder.go
@@ -3,9 +3,9 @@ package opus
 import (
 	"errors"
 
-	"github.com/dosgo/concentus/go/celt"
-	"github.com/dosgo/concentus/go/comm"
-	"github.com/dosgo/concentus/go/silk"
+	"github.com/lostromb/concentus/go/celt"
+	"github.com/lostromb/concentus/go/comm"
+	"github.com/lostromb/concentus/go/silk"
 )
 
 type OpusDecoder struct {

--- a/Go/opus/OpusEncoder.go
+++ b/Go/opus/OpusEncoder.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/dosgo/concentus/go/celt"
-	"github.com/dosgo/concentus/go/comm"
-	"github.com/dosgo/concentus/go/comm/opusConstants"
-	"github.com/dosgo/concentus/go/silk"
+	"github.com/lostromb/concentus/go/celt"
+	"github.com/lostromb/concentus/go/comm"
+	"github.com/lostromb/concentus/go/comm/opusConstants"
+	"github.com/lostromb/concentus/go/silk"
 )
 
 type OpusEncoder struct {

--- a/Go/opus/OpusMSDecoder.go
+++ b/Go/opus/OpusMSDecoder.go
@@ -3,7 +3,7 @@ package opus
 import (
 	"errors"
 
-	"github.com/dosgo/concentus/go/comm"
+	"github.com/lostromb/concentus/go/comm"
 )
 
 type OpusMSDecoder struct {

--- a/Go/opus/OpusMSEncoder.go
+++ b/Go/opus/OpusMSEncoder.go
@@ -3,9 +3,9 @@ package opus
 import (
 	"errors"
 
-	"github.com/dosgo/concentus/go/celt"
-	"github.com/dosgo/concentus/go/comm"
-	"github.com/dosgo/concentus/go/comm/opusConstants"
+	"github.com/lostromb/concentus/go/celt"
+	"github.com/lostromb/concentus/go/comm"
+	"github.com/lostromb/concentus/go/comm/opusConstants"
 )
 
 type OpusMSEncoder struct {

--- a/Go/opus/OpusPacketInfo.go
+++ b/Go/opus/OpusPacketInfo.go
@@ -3,7 +3,7 @@ package opus
 import (
 	"errors"
 
-	"github.com/dosgo/concentus/go/comm"
+	"github.com/lostromb/concentus/go/comm"
 )
 
 type OpusPacketInfo struct {

--- a/Go/opus/OpusRepacketizer.go
+++ b/Go/opus/OpusRepacketizer.go
@@ -3,7 +3,7 @@ package opus
 import (
 	"bytes"
 
-	"github.com/dosgo/concentus/go/comm"
+	"github.com/lostromb/concentus/go/comm"
 )
 
 type OpusRepacketizer struct {

--- a/Go/opus/TonalityAnalysisState.go
+++ b/Go/opus/TonalityAnalysisState.go
@@ -1,8 +1,8 @@
 package opus
 
 import (
-	"github.com/dosgo/concentus/go/celt"
-	"github.com/dosgo/concentus/go/comm/opusConstants"
+	"github.com/lostromb/concentus/go/celt"
+	"github.com/lostromb/concentus/go/comm/opusConstants"
 )
 
 type TonalityAnalysisState struct {

--- a/Go/opus/analysis.go
+++ b/Go/opus/analysis.go
@@ -3,8 +3,8 @@ package opus
 import (
 	"math"
 
-	"github.com/dosgo/concentus/go/celt"
-	"github.com/dosgo/concentus/go/comm/opusConstants"
+	"github.com/lostromb/concentus/go/celt"
+	"github.com/lostromb/concentus/go/comm/opusConstants"
 )
 
 const (

--- a/Go/opus/import.go
+++ b/Go/opus/import.go
@@ -1,9 +1,9 @@
 package opus
 
 import (
-	"github.com/dosgo/concentus/go/celt"
-	"github.com/dosgo/concentus/go/comm"
-	"github.com/dosgo/concentus/go/silk"
+	"github.com/lostromb/concentus/go/celt"
+	"github.com/lostromb/concentus/go/comm"
+	"github.com/lostromb/concentus/go/silk"
 )
 
 var inlines = comm.Inlines{}

--- a/Go/silk/BurgModified.go
+++ b/Go/silk/BurgModified.go
@@ -3,8 +3,8 @@ package silk
 import (
 	"math"
 
-	"github.com/dosgo/concentus/go/comm"
-	"github.com/dosgo/concentus/go/comm/arrayUtil"
+	"github.com/lostromb/concentus/go/comm"
+	"github.com/lostromb/concentus/go/comm/arrayUtil"
 )
 
 const (

--- a/Go/silk/CNG.go
+++ b/Go/silk/CNG.go
@@ -1,6 +1,6 @@
 package silk
 
-import "github.com/dosgo/concentus/go/comm"
+import "github.com/lostromb/concentus/go/comm"
 
 const MaxInt16 = 32767
 

--- a/Go/silk/CNGState.go
+++ b/Go/silk/CNGState.go
@@ -32,7 +32,7 @@
  */
 package silk
 
-import "github.com/dosgo/concentus/go/comm/arrayUtil"
+import "github.com/lostromb/concentus/go/comm/arrayUtil"
 
 type CNGState struct {
 	CNG_exc_buf_Q14   []int

--- a/Go/silk/CodeSigns.go
+++ b/Go/silk/CodeSigns.go
@@ -1,6 +1,6 @@
 package silk
 
-import "github.com/dosgo/concentus/go/comm"
+import "github.com/lostromb/concentus/go/comm"
 
 func silk_enc_map(a int) int {
 	return inlines.Silk_RSHIFT(a, 15) + 1

--- a/Go/silk/CorrelateMatrix.go
+++ b/Go/silk/CorrelateMatrix.go
@@ -1,6 +1,6 @@
 package silk
 
-import "github.com/dosgo/concentus/go/comm"
+import "github.com/lostromb/concentus/go/comm"
 
 type correlateMatrix struct{}
 

--- a/Go/silk/DecodeCore.go
+++ b/Go/silk/DecodeCore.go
@@ -3,7 +3,7 @@ package silk
 import (
 	"math"
 
-	"github.com/dosgo/concentus/go/comm/arrayUtil"
+	"github.com/lostromb/concentus/go/comm/arrayUtil"
 )
 
 func silk_decode_core(

--- a/Go/silk/DecodeIndices.go
+++ b/Go/silk/DecodeIndices.go
@@ -1,6 +1,6 @@
 package silk
 
-import "github.com/dosgo/concentus/go/comm"
+import "github.com/lostromb/concentus/go/comm"
 
 func Silk_decode_indices(psDec *SilkChannelDecoder, psRangeDec *comm.EntropyCoder, FrameIndex int, decode_LBRR int, condCoding int) {
 	var i, k, Ix int

--- a/Go/silk/DecodeParameters.go
+++ b/Go/silk/DecodeParameters.go
@@ -1,8 +1,8 @@
 package silk
 
 import (
-	"github.com/dosgo/concentus/go/comm"
-	"github.com/dosgo/concentus/go/comm/arrayUtil"
+	"github.com/lostromb/concentus/go/comm"
+	"github.com/lostromb/concentus/go/comm/arrayUtil"
 )
 
 func silk_decode_parameters(

--- a/Go/silk/DecodePulses.go
+++ b/Go/silk/DecodePulses.go
@@ -1,6 +1,6 @@
 package silk
 
-import "github.com/dosgo/concentus/go/comm"
+import "github.com/lostromb/concentus/go/comm"
 
 func Silk_decode_pulses(
 	psRangeDec *comm.EntropyCoder,

--- a/Go/silk/EncodeIndices.go
+++ b/Go/silk/EncodeIndices.go
@@ -1,6 +1,6 @@
 package silk
 
-import "github.com/dosgo/concentus/go/comm"
+import "github.com/lostromb/concentus/go/comm"
 
 func Silk_encode_indices(psEncC *SilkChannelEncoder, psRangeEnc *comm.EntropyCoder, FrameIndex int, encode_LBRR int, condCoding int) {
 	var i, k, typeOffset int

--- a/Go/silk/EncodePulses.go
+++ b/Go/silk/EncodePulses.go
@@ -1,6 +1,6 @@
 package silk
 
-import "github.com/dosgo/concentus/go/comm"
+import "github.com/lostromb/concentus/go/comm"
 
 func combine_and_check(pulses_comb []int, pulses_comb_ptr int, pulses_in []int, pulses_in_ptr int, max_pulses int, _len int) int {
 	for k := 0; k < _len; k++ {

--- a/Go/silk/FindLPC.go
+++ b/Go/silk/FindLPC.go
@@ -1,6 +1,6 @@
 package silk
 
-import "github.com/dosgo/concentus/go/comm"
+import "github.com/lostromb/concentus/go/comm"
 
 func silk_find_LPC(
 	psEncC *SilkChannelEncoder,

--- a/Go/silk/FindPitchLags.go
+++ b/Go/silk/FindPitchLags.go
@@ -3,7 +3,7 @@ package silk
 import (
 	"math"
 
-	"github.com/dosgo/concentus/go/comm"
+	"github.com/lostromb/concentus/go/comm"
 )
 
 func silk_find_pitch_lags(psEnc *SilkChannelEncoder, psEncCtrl *SilkEncoderControl, res []int16, x []int16, x_ptr int) {

--- a/Go/silk/FindPredCoefs.go
+++ b/Go/silk/FindPredCoefs.go
@@ -3,8 +3,8 @@ package silk
 import (
 	"math"
 
-	"github.com/dosgo/concentus/go/comm"
-	"github.com/dosgo/concentus/go/comm/arrayUtil"
+	"github.com/lostromb/concentus/go/comm"
+	"github.com/lostromb/concentus/go/comm/arrayUtil"
 )
 
 func silk_find_pred_coefs(

--- a/Go/silk/GainQuantization.go
+++ b/Go/silk/GainQuantization.go
@@ -32,7 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 package silk
 
-import "github.com/dosgo/concentus/go/comm"
+import "github.com/lostromb/concentus/go/comm"
 
 var OFFSET = ((MIN_QGAIN_DB*128)/6 + 16*128)
 var SCALE_Q16 = ((65536 * (N_LEVELS_QGAIN - 1)) / (((MAX_QGAIN_DB - MIN_QGAIN_DB) * 128) / 6))

--- a/Go/silk/LPCInversePredGain.go
+++ b/Go/silk/LPCInversePredGain.go
@@ -33,7 +33,7 @@ package silk
 import (
 	"math"
 
-	"github.com/dosgo/concentus/go/comm/arrayUtil"
+	"github.com/lostromb/concentus/go/comm/arrayUtil"
 )
 
 const QA24 = 24

--- a/Go/silk/NLSF.go
+++ b/Go/silk/NLSF.go
@@ -3,7 +3,7 @@ package silk
 import (
 	"math"
 
-	"github.com/dosgo/concentus/go/comm/arrayUtil"
+	"github.com/lostromb/concentus/go/comm/arrayUtil"
 )
 
 const (

--- a/Go/silk/NoiseShapeAnalysis.go
+++ b/Go/silk/NoiseShapeAnalysis.go
@@ -3,7 +3,7 @@ package silk
 import (
 	"math"
 
-	"github.com/dosgo/concentus/go/comm"
+	"github.com/lostromb/concentus/go/comm"
 )
 
 func warped_gain(coefs_Q24 []int, lambda_Q16 int, order int) int {

--- a/Go/silk/PLC.go
+++ b/Go/silk/PLC.go
@@ -1,6 +1,6 @@
 package silk
 
-import "github.com/dosgo/concentus/go/comm"
+import "github.com/lostromb/concentus/go/comm"
 
 const (
 	NB_ATT = 2

--- a/Go/silk/PLCStruct.go
+++ b/Go/silk/PLCStruct.go
@@ -33,7 +33,7 @@ Copyright (c) 2006-2011 Skype Limited. All Rights Reserved
 */
 package silk
 
-import "github.com/dosgo/concentus/go/comm/arrayUtil"
+import "github.com/lostromb/concentus/go/comm/arrayUtil"
 
 ///
 /// <summary>

--- a/Go/silk/PitchAnalysisCore.go
+++ b/Go/silk/PitchAnalysisCore.go
@@ -3,8 +3,8 @@ package silk
 import (
 	"math"
 
-	"github.com/dosgo/concentus/go/comm"
-	"github.com/dosgo/concentus/go/comm/arrayUtil"
+	"github.com/lostromb/concentus/go/comm"
+	"github.com/lostromb/concentus/go/comm/arrayUtil"
 )
 
 const (

--- a/Go/silk/ProcessGains.go
+++ b/Go/silk/ProcessGains.go
@@ -3,7 +3,7 @@ package silk
 import (
 	"math"
 
-	"github.com/dosgo/concentus/go/comm"
+	"github.com/lostromb/concentus/go/comm"
 )
 
 func silk_process_gains(

--- a/Go/silk/QuantizeLTPGains.go
+++ b/Go/silk/QuantizeLTPGains.go
@@ -3,7 +3,7 @@ package silk
 import (
 	"math"
 
-	"github.com/dosgo/concentus/go/comm"
+	"github.com/lostromb/concentus/go/comm"
 )
 
 func silk_quant_LTP_gains(

--- a/Go/silk/ResidualEnergy.go
+++ b/Go/silk/ResidualEnergy.go
@@ -1,6 +1,6 @@
 package silk
 
-import "github.com/dosgo/concentus/go/comm"
+import "github.com/lostromb/concentus/go/comm"
 
 func silk_residual_energy(
 	nrgs []int,

--- a/Go/silk/Schur.go
+++ b/Go/silk/Schur.go
@@ -3,7 +3,7 @@ package silk
 import (
 	"math"
 
-	"github.com/dosgo/concentus/go/comm/arrayUtil"
+	"github.com/lostromb/concentus/go/comm/arrayUtil"
 )
 
 func MemSetInt(array []int, value, length int) {

--- a/Go/silk/ShellCoder.go
+++ b/Go/silk/ShellCoder.go
@@ -1,6 +1,6 @@
 package silk
 
-import "github.com/dosgo/concentus/go/comm"
+import "github.com/lostromb/concentus/go/comm"
 
 func combine_pulsesLen(output, input []int, input_ptr int, len int) {
 	var k int

--- a/Go/silk/Stereo.go
+++ b/Go/silk/Stereo.go
@@ -3,8 +3,8 @@ package silk
 import (
 	"math"
 
-	"github.com/dosgo/concentus/go/comm"
-	"github.com/dosgo/concentus/go/comm/arrayUtil"
+	"github.com/lostromb/concentus/go/comm"
+	"github.com/lostromb/concentus/go/comm/arrayUtil"
 )
 
 func Silk_stereo_decode_pred(

--- a/Go/silk/StereoEncodeState.go
+++ b/Go/silk/StereoEncodeState.go
@@ -1,6 +1,6 @@
 package silk
 
-import "github.com/dosgo/concentus/go/comm/arrayUtil"
+import "github.com/lostromb/concentus/go/comm/arrayUtil"
 
 type StereoEncodeState struct {
 	Pred_prev_Q13   [2]int16

--- a/Go/silk/SumSqrShift.go
+++ b/Go/silk/SumSqrShift.go
@@ -30,7 +30,7 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package silk
 
-import "github.com/dosgo/concentus/go/comm"
+import "github.com/lostromb/concentus/go/comm"
 
 func silk_sum_sqr_shift5(energy *comm.BoxedValueInt, shift *comm.BoxedValueInt, x []int16, x_ptr int, _len int) {
 	var i int

--- a/Go/silk/VQ_WMat_EC.go
+++ b/Go/silk/VQ_WMat_EC.go
@@ -3,7 +3,7 @@ package silk
 import (
 	"math"
 
-	"github.com/dosgo/concentus/go/comm"
+	"github.com/lostromb/concentus/go/comm"
 )
 
 func silk_VQ_WMat_EC(ind *comm.BoxedValueByte, rate_dist_Q14 *comm.BoxedValueInt, gain_Q7 *comm.BoxedValueInt, in_Q14 []int16, in_Q14_ptr int, W_Q18 []int, W_Q18_ptr int, cb_Q7 [][]int8, cb_gain_Q7 []int16, cl_Q5 []int16, mu_Q9 int, max_gain_Q7 int, L int) {

--- a/Go/silk/findLTP.go
+++ b/Go/silk/findLTP.go
@@ -3,7 +3,7 @@ package silk
 import (
 	"math"
 
-	"github.com/dosgo/concentus/go/comm"
+	"github.com/lostromb/concentus/go/comm"
 )
 
 const LTP_CORRS_HEAD_ROOM = 2

--- a/Go/silk/import.go
+++ b/Go/silk/import.go
@@ -1,6 +1,6 @@
 package silk
 
-import "github.com/dosgo/concentus/go/comm"
+import "github.com/lostromb/concentus/go/comm"
 
 var inlines = comm.Inlines{}
 var kernels = comm.Kernels{}

--- a/Go/silk/silk_NSQState.go
+++ b/Go/silk/silk_NSQState.go
@@ -1,6 +1,6 @@
 package silk
 
-import "github.com/dosgo/concentus/go/comm"
+import "github.com/lostromb/concentus/go/comm"
 
 type NSQ_del_dec_struct struct {
 	sLPC_Q14  []int

--- a/Go/silk/silk_ResamplerState.go
+++ b/Go/silk/silk_ResamplerState.go
@@ -1,7 +1,7 @@
 package silk
 
 import (
-	"github.com/dosgo/concentus/go/comm/arrayUtil"
+	"github.com/lostromb/concentus/go/comm/arrayUtil"
 )
 
 type SilkResamplerState struct {

--- a/Go/silk/silk_VADState.go
+++ b/Go/silk/silk_VADState.go
@@ -1,6 +1,6 @@
 package silk
 
-import arrayutil "github.com/dosgo/concentus/go/comm/arrayUtil"
+import arrayutil "github.com/lostromb/concentus/go/comm/arrayUtil"
 
 type SilkVADState struct {
 	AnaState        []int

--- a/Go/silk/silk_channelDecoder.go
+++ b/Go/silk/silk_channelDecoder.go
@@ -1,8 +1,8 @@
 package silk
 
 import (
-	"github.com/dosgo/concentus/go/comm"
-	"github.com/dosgo/concentus/go/comm/arrayUtil"
+	"github.com/lostromb/concentus/go/comm"
+	"github.com/lostromb/concentus/go/comm/arrayUtil"
 )
 
 type SilkChannelDecoder struct {

--- a/Go/silk/silk_channelEncoder.go
+++ b/Go/silk/silk_channelEncoder.go
@@ -3,8 +3,8 @@ package silk
 import (
 	"math"
 
-	"github.com/dosgo/concentus/go/comm"
-	"github.com/dosgo/concentus/go/comm/arrayUtil"
+	"github.com/lostromb/concentus/go/comm"
+	"github.com/lostromb/concentus/go/comm/arrayUtil"
 )
 
 type SilkChannelEncoder struct {

--- a/Go/silk/silk_decoderControl.go
+++ b/Go/silk/silk_decoderControl.go
@@ -1,6 +1,6 @@
 package silk
 
-import "github.com/dosgo/concentus/go/comm/arrayUtil"
+import "github.com/lostromb/concentus/go/comm/arrayUtil"
 
 type SilkDecoderControl struct {
 	pitchL        []int

--- a/Go/silk/silk_encodereontrol.go
+++ b/Go/silk/silk_encodereontrol.go
@@ -1,6 +1,6 @@
 package silk
 
-import "github.com/dosgo/concentus/go/comm/arrayUtil"
+import "github.com/lostromb/concentus/go/comm/arrayUtil"
 
 type SilkEncoderControl struct {
 	Gains_Q16          []int

--- a/Go/test/test.go
+++ b/Go/test/test.go
@@ -11,8 +11,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/dosgo/concentus/go/comm"
-	"github.com/dosgo/concentus/go/opus"
+	"github.com/lostromb/concentus/go/comm"
+	"github.com/lostromb/concentus/go/opus"
 )
 
 func main() {


### PR DESCRIPTION
Sorry! I was using a go.mod generated from a development version, which caused go get to fail. This has been fixed, and the package name has been changed to github.com/lostromb/concentus/go.